### PR TITLE
Update Gulpfile.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -62,6 +62,7 @@ gulp.task('sync', ['dev'], function() {
     sync.init({
         port: 3006,
         proxy: proxy,
+        cors: true,
         serveStatic: ['.'],
         ui: {
             port: 3007


### PR DESCRIPTION
That way the access from a specific project to a Snipcart icon font wouldn't be blocked by CORS policy when proxying css file as suggested.