### PR TITLE
Fix conflict with Gulp's CLI version flag

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -5,7 +5,7 @@ var concat = require('gulp-concat');
 var minifyCss = require('gulp-minify-css');
 var rename = require('gulp-rename');
 var autoprefixer = require('gulp-autoprefixer');
-var argv = require('yargs').option('version', {type: 'string'}).argv;
+var argv = require('yargs').option('release', {type: 'string'}).argv;
 var postcss = require('gulp-postcss');
 var mqpacker = require('css-mqpacker');
 var browserSync = require('browser-sync');
@@ -26,8 +26,8 @@ var watch = {
 var getDistDir = function (output) {
     var dir = './dist/themes';
 
-    if (argv.version) {
-        dir = "./dist/themes/" + argv.version;
+    if (argv.release) {
+        dir = "./dist/themes/" + argv.release;
     }
 
     if (output) {

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ By default, Browsersync will serve the content on `localhost:3006`. If you wish 
 ​
 To generate assets to be deployed, you can use the `deploy` gulp task. This task will make sure to copy files needed to `dist` folder and `snipcart.css` + `snipcart.min.css`. Images, fonts, and more will also be copied to the `dist` folder.
 ​
-You may use the `version` flag to create a version directory inside the `dist` folder.
+You may use the `release` flag to create a version directory inside the `dist` folder.
 ​
 ```sh
-gulp deploy --version 1.2.3
+gulp deploy --release 1.2.3
 ```
 ​
 The example above would generate the following directory structure:


### PR DESCRIPTION
Gulp has a --version flag. This commit changes the word `version` to
`release` to avoid that conflict. The name can be anything. `release` seemed a logical choice.